### PR TITLE
Fix Path conflict

### DIFF
--- a/projects/demo-app-electron/tsconfig.app.json
+++ b/projects/demo-app-electron/tsconfig.app.json
@@ -5,9 +5,6 @@
   "compilerOptions": {
     "outDir": "../../out-tsc/app",
     "types": [],
-    "paths": {
-      "@dotted-labs/ngx-supabase-auth": ["../../dist/ngx-supabase-auth"]
-    }
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.d.ts"]

--- a/projects/demo-app/tsconfig.app.json
+++ b/projects/demo-app/tsconfig.app.json
@@ -5,9 +5,6 @@
   "compilerOptions": {
     "outDir": "../../out-tsc/app",
     "types": [],
-    "paths": {
-      "@dotted-labs/ngx-supabase-auth": ["../ngx-supabase-auth/src/public-api"]
-    }
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.d.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
-      "ngx-supabase-auth": [
+      "@dotted-labs/ngx-supabase-auth": [
         "./dist/ngx-supabase-auth"
       ]
     },


### PR DESCRIPTION
**Summary**
This PR resolves path resolution issues when import dotted-labs/ngx-supabase-auth in the existings demo apps.

**Changes**
Updated root tsconfig.json to use the correct scoped package name (@dotted-labs/ngx-supabase-auth) and removed from the example apps.

**Technical Details**
The root issue was that the TypeScript path configuration in the root tsconfig.json was using the unscoped library name (ngx-supabase-auth), while the actual imports and package naming throughout the codebase were using the scoped package name (@dotted-labs/ngx-supabase-auth). This PR aligns these configurations to ensure TypeScript properly resolves all imports.